### PR TITLE
added JupyterLab-generated identity to comments

### DIFF
--- a/src/commentformat.ts
+++ b/src/commentformat.ts
@@ -23,10 +23,15 @@ export type CommentTarget =
 
 export type CommentType = 'null' | 'cell' | 'text';
 
+export interface IIdentity {
+  id: number;
+  name: string;
+}
+
 export type IComment = {
   id: string;
   type: CommentType;
-  author: string;
+  identity: IIdentity;
   replies: IComment[];
   text: string;
 };

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -10,7 +10,9 @@ export function verifyComment(comment: Record<string, unknown>): boolean {
   return (
     'id' in comment &&
     'type' in comment &&
-    'author' in comment &&
+    'identity' in comment &&
+    'id' in (comment['identity'] as comments.IIdentity) &&
+    'name' in (comment['identity'] as comments.IIdentity) &&
     'text' in comment &&
     'replies' in comment
   );
@@ -66,5 +68,5 @@ export function addReply(
   }
 
   comments[commentIndex].replies.push(reply);
-  metadata.set('comments', comments);
+  metadata.set('comments', comments as any);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,24 @@
+import { Awareness } from 'y-protocols/awareness';
+import { IIdentity } from './commentformat';
+
+export const emptyIdentity: IIdentity = {
+  id: 0,
+  name: ''
+};
+
+export function getIdentity(awareness: Awareness): IIdentity {
+  const localState = awareness.getLocalState();
+  if (localState == null) {
+    return emptyIdentity;
+  }
+
+  const userInfo = localState['user'];
+  if ('name' in userInfo) {
+    return {
+      id: awareness.clientID,
+      name: userInfo['name']
+    };
+  }
+
+  return emptyIdentity;
+}


### PR DESCRIPTION
- Comments names are now based on the JupyterLab-generated "Anonymous [moon]" format.
- Comment widgets take an `Awareness` as part of the constructor
- `IComment` objects have an identity field of type `IIdentity`