### PR TITLE
added 'profile pic'; style changes

### DIFF
--- a/src/commentformat.ts
+++ b/src/commentformat.ts
@@ -9,6 +9,7 @@ export type CommentType = 'null' | 'cell' | 'text';
 export interface IIdentity {
   id: number;
   name: string;
+  color: string;
 }
 
 /**

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -13,6 +13,7 @@ export function verifyComment(comment: Record<string, unknown>): boolean {
     'identity' in comment &&
     'id' in (comment['identity'] as comments.IIdentity) &&
     'name' in (comment['identity'] as comments.IIdentity) &&
+    'color' in (comment['identity'] as comments.IIdentity) &&
     'text' in comment &&
     'replies' in comment &&
     'time' in comment

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,8 @@ import { IIdentity } from './commentformat';
 
 export const emptyIdentity: IIdentity = {
   id: 0,
-  name: ''
+  name: '',
+  color: ''
 };
 
 export function getIdentity(awareness: Awareness): IIdentity {
@@ -13,10 +14,11 @@ export function getIdentity(awareness: Awareness): IIdentity {
   }
 
   const userInfo = localState['user'];
-  if ('name' in userInfo) {
+  if ('name' in userInfo && 'color' in userInfo) {
     return {
       id: awareness.clientID,
-      name: userInfo['name']
+      name: userInfo['name'],
+      color: userInfo['color']
     };
   }
 

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -1,6 +1,6 @@
 import { ReactWidget } from '@jupyterlab/apputils';
 import * as React from 'react';
-import { closeIcon, editIcon} from '@jupyterlab/ui-components';
+import { closeIcon, editIcon } from '@jupyterlab/ui-components';
 import { CommentType, IComment, IIdentity } from './commentformat';
 import { IObservableJSON } from '@jupyterlab/observables';
 import { UUID } from '@lumino/coreutils';
@@ -31,9 +31,17 @@ function JCComment(props: CommentProps): JSX.Element {
 
   return (
     <div className={className || ''} id={comment.id}>
-      <p className="jc-Nametag">{comment.identity.name}</p>
+      <div className="jc-ProfilePicContainer">
+        <div
+          className="jc-ProfilePic"
+          style={{ backgroundColor: comment.identity.color }}
+        />
+      </div>
+      <span className="jc-Nametag">{comment.identity.name}</span>
       <br />
-      <p className="jc-Time">{comment.time}</p>
+      <span className="jc-Time">{comment.time}</span>
+      <br />
+      <br />
       <p className="jc-Body" onClick={onBodyClick}>
         {comment.text}
       </p>
@@ -44,9 +52,7 @@ function JCComment(props: CommentProps): JSX.Element {
       >
         <closeIcon.react />
       </button>
-      <button 
-        className="jc-DeleteButton jp-Button bp3-button bp3-minimal"
-      >
+      <button className="jc-DeleteButton jp-Button bp3-button bp3-minimal">
         <editIcon.react />
       </button>
     </div>
@@ -85,19 +91,21 @@ export class CommentWidget<T> extends ReactWidget {
           return;
         }
 
-        const target = e.target as HTMLTextAreaElement;
+        e.preventDefault();
+        e.stopPropagation();
+        const target = e.target as HTMLDivElement;
 
         const reply: IComment = {
           id: UUID.uuid4(),
           type: 'cell',
           identity: getIdentity(this._awareness),
           replies: [],
-          text: target.value,
+          text: target.textContent!,
           time: new Date(new Date().getTime()).toLocaleString()
         };
 
         addReply(metadata, reply, commentID);
-        target.value = '';
+        target.textContent = '';
         setIsHidden(true);
       };
 
@@ -124,15 +132,15 @@ export class CommentWidget<T> extends ReactWidget {
               />
             ))}
           </div>
-          <textarea
+          <div
             className="jc-InputArea"
             hidden={isHidden}
             onKeyDown={onInputKeydown}
+            contentEditable={true}
           />
         </div>
       );
     };
-
 
     return <_CommentWrapper comment={this.comment!} />;
   }
@@ -186,7 +194,7 @@ export class CommentWidget<T> extends ReactWidget {
       commentList.splice(commentIndex, 1);
       this._metadata.set('comments', commentList as any);
       this.dispose();
-    } 
+    }
   }
 
   get comment(): IComment | undefined {

--- a/style/base.css
+++ b/style/base.css
@@ -1,35 +1,28 @@
 .jc-CommentPanel {
-  background-color: white;
-}
-
-.subclass {
-  background-color: gray;
-  color: black;
+  background-color: var(--jp-layout-color0);
+  overflow: auto;
 }
 
 .jc-Comment {
-  background-color: lightblue;
-  width: 100%;
-  margin: 4px 8px 4px 8px;
+  background-color: var(--jp-layout-color1);
+  padding: 15px;
+  border: 1px solid #c5c5c5;
+  color: var(--jp-ui-font-color0);
 }
 
 .jc-Nametag {
-  width: 30%;
-  display: inline-block;
-  top: 0px;
+  font-weight: bold;
+  margin-left: 10px;
 }
 
 .jc-Time {
-  width: 70%;
-  display: inline-block;
-  top: 0px;
   font-size: x-small;
+  vertical-align: top;
+  margin-left: 10px;
 }
 
 .jc-Body {
-  width: 70%;
   display: inline-block;
-  top: 0px;
 }
 
 .jc-DeleteButton {
@@ -38,11 +31,36 @@
 }
 
 .jc-Reply {
-  margin-left: 30px;
+  border-top: none;
 }
 
 .jc-CommentInput {
   width: 100%;
   min-height: 44px;
   padding: 5px 4px;
+}
+
+.jc-ProfilePic {
+  display: inline-block;
+  border-radius: 50%;
+  top: 0;
+  left: 0;
+  height: 30px;
+  width: 30px;
+}
+
+.jc-ProfilePicContainer {
+  float: left;
+  width: 30px;
+}
+
+.jc-CommentWithReplies {
+  margin: 0 8px 12px 8px;
+}
+
+.jc-InputArea {
+  border: 1px solid #c5c5c5;
+  border-top: none;
+  padding: 5px 4px;
+  min-height: 44px;
 }


### PR DESCRIPTION
Addresses Issue #27

- Added a circular "profile picture" stand-in in the user's JupyterLab-assigned color.
- Big style changes! Still not entirely in line with the vision of #26 but much better.
- Replaced reply textarea with a contentEditable div.
- Fixed a bug causing an extra newline after a reply.

![nice_comments](https://user-images.githubusercontent.com/38936057/124159946-93646080-da50-11eb-9189-29f0c2a49799.gif)
