### PR TITLE
Dropdown menu and focus tracker

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,7 @@ include ts*.json
 include yarn.lock
 
 exclude lint-staged.config.js
+exclude Press_Release.md
 
 graft jupyterlab_chat/labextension
 

--- a/Press_Release.md
+++ b/Press_Release.md
@@ -1,0 +1,18 @@
+Press Release
+
+JupyterLab Commenting
+---
+ 
+**Teams can now comment on and annotate files within JupyterLab in real time.**
+ 
+Real-time collaboration (RTC) is now a core part of JupyterLab. Communication is vital for effective RTC, but until now, has been unavailable within JupyterLab. The commenting extension gives users a voice with live comments, quick replies, and search and filter.
+ 
+When working together on notebooks, collaborators often have recommendations and opinions about code and data. These recommendations have to be relayed outside JupyterLab, and it is hard to quickly convey exactly what needs to be changed and how--especially if the whole team isn’t using Git/GitHub. Without commenting and annotation, teams often find that JupyterLab doesn’t cut it for serious collaboration.
+ 
+The JupyterLab Commenting extension streamlines communication and enables users to comment on almost anything, including cells, outputs, text selections, datasets, and images. Comments are in markdown and support in-line LaTeX, as well as custom tags that allow you to easily label, sort, and search your team’s comments. Once created, comments live in a collapsible side panel where they can be searched and filtered for easy access. Quick replies allow users to swiftly address concerns while keeping in touch with their team by supplying common responses that can be sent with a single click.
+ 
+Commenting is easy, intuitive, and similar to other commenting systems users are familiar with. Simply highlight, right-click, and select “Add Comment” to comment on cells, text selections, and more. In addition, quick replies and non-intrusive notifications will help you seamlessly blend commenting into your existing workflow.  
+ 
+*“Integrated commenting helped my team streamline our feedback process so we didn’t have to hold as many meetings. It also allowed me to collaborate with newer users that weren’t familiar with GitHub”* ~ Satisfied User
+ 
+Don’t wait to collaborate! Open up new channels of communication with JupyterLab commenting. 

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -1,6 +1,7 @@
 import { every } from '@lumino/algorithm';
 import { IObservableJSON } from '@jupyterlab/observables';
 import * as comments from './commentformat';
+import { getCommentTimeString } from './utils';
 
 export function verifyComments(comments: Record<string, unknown>): boolean {
   return Array.isArray(comments) && every(comments, verifyComment);
@@ -54,6 +55,58 @@ export function addComment(
   }
 }
 
+export function edit(
+  metadata: IObservableJSON,
+  commentid: string,
+  editid: string,
+  modifiedText: string
+): void {
+  const comment = getCommentByID(metadata, commentid);
+  if (comment == null) {
+    return;
+  }
+  if (editid == commentid) {
+    editComment(metadata, commentid, modifiedText);
+  } else {
+    editReply(metadata, commentid, editid, modifiedText);
+  }
+}
+
+function editReply(
+  metadata: IObservableJSON,
+  commentid: string,
+  id: string,
+  modifiedText: string
+): void {
+  const comment = getCommentByID(metadata, commentid);
+  if (comment == null) {
+    console.warn('Comment does not exist!');
+    return;
+  }
+  const replyIndex = comment.replies.findIndex(r => r.id === id);
+  if (replyIndex === -1) {
+    return;
+  }
+  comment.replies[replyIndex].text = modifiedText;
+  // Maybe we should inclued an edited flag to render?
+  comment.time = getCommentTimeString(); 
+}
+
+function editComment(
+  metadata: IObservableJSON,
+  id: string,
+  modifiedText: string
+): void {
+  const comment = getCommentByID(metadata, id);
+  if (comment == null) {
+    console.warn('Comment does not exist!');
+    return;
+  }
+  comment.text = modifiedText;
+  // Maybe we should inclued an edited flag to render?
+  comment.time = getCommentTimeString(); 
+}
+
 export function addReply(
   metadata: IObservableJSON,
   reply: comments.IComment,
@@ -91,19 +144,14 @@ export function deleteReply(
   comment.replies.splice(replyIndex, 1);
   comments[commentIndex] = comment;
   metadata.set('comments', comments as any);
-
 }
 
-export function deleteComment(
-  metadata: IObservableJSON,
-  id: string
-): void {
+export function deleteComment(metadata: IObservableJSON, id: string): void {
   const comments = getComments(metadata);
   if (comments == null) {
     return;
   }
-  const commentIndex = comments.findIndex(c=> c.id === id);
+  const commentIndex = comments.findIndex(c => c.id === id);
   comments.splice(commentIndex, 1);
   metadata.set('comments', comments as any);
-
 }

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -1,12 +1,13 @@
 import { ReactWidget } from '@jupyterlab/apputils';
 import * as React from 'react';
-import { closeIcon, editIcon } from '@jupyterlab/ui-components';
+import { ellipsesIcon } from '@jupyterlab/ui-components';
 import { CommentType, IComment, IIdentity } from './commentformat';
 import { IObservableJSON } from '@jupyterlab/observables';
 import { UUID } from '@lumino/coreutils';
-import { addReply, deleteComment, deleteReply, edit } from './comments';
+import { addReply, edit } from './comments';
 import { Awareness } from 'y-protocols/awareness';
 import { getCommentTimeString, getIdentity } from './utils';
+import { Menu } from '@lumino/widgets';
 
 /**
  * This type comes from @jupyterlab/apputils/vdom.ts but isn't exported.
@@ -19,19 +20,41 @@ type CommentProps = {
   comment: IComment;
   className: string;
   content: ReactRenderElement;
-  onDeleteClick: React.MouseEventHandler;
   onEditClick: React.MouseEventHandler;
+  onBodyClick: React.MouseEventHandler;
+  onDropdownClick: React.MouseEventHandler;
 };
 
 type CommentWrapperProps = {
   comment: IComment;
 };
 
+/**
+ * A React component that renders a single comment or reply.
+ *
+ * @param comment - the comment object to render. Note: Replies will
+ * not be rendered.
+ *
+ * @param className - a string that will be used as the className of the
+ * container element.
+ *
+ * @param onBodyClick - a function that will be run when the comment is clicked.
+ *
+ * @param onDropdownClick - a function that will be run when the comment's
+ * dropdown (ellipses) menu is clicked.
+ */
 function JCComment(props: CommentProps): JSX.Element {
-  const { comment, className, content, onEditClick, onDeleteClick } = props;
+  const {
+    comment,
+    className,
+    content,
+    onBodyClick,
+    onDropdownClick,
+    onEditClick
+  } = props;
 
   return (
-    <div className={className || ''} id={comment.id}>
+    <div className={className || ''} id={comment.id} onClick={onBodyClick}>
       <div className="jc-ProfilePicContainer">
         <div
           className="jc-ProfilePic"
@@ -39,39 +62,40 @@ function JCComment(props: CommentProps): JSX.Element {
         />
       </div>
       <span className="jc-Nametag">{comment.identity.name}</span>
+      <span onClick={onDropdownClick}>
+        <ellipsesIcon.react className="jc-Ellipses" tag="span" />
+      </span>
       <br />
       <span className="jc-Time">{comment.time}</span>
       <br />
 
       {/* the actual content */}
-      {content}
+      <div className="jc-ContentContainer" onClick={onEditClick}>
+        {content}
+      </div>
 
       <br />
-      <button
-        className="jc-DeleteButton jp-Button bp3-button bp3-minimal"
-        onClick={onDeleteClick}
-      >
-        <closeIcon.react />
-      </button>
-      <button
-        className="jc-EditButton jp-Button bp3-button bp3-minimal"
-        onClick={onEditClick}
-      >
-        <editIcon.react />
-      </button>
     </div>
   );
 }
 
+/**
+ * A ReactWidget that renders a comment and its replies.
+ */
 export class CommentWidget<T> extends ReactWidget {
   constructor(options: CommentWidget.IOptions<T>) {
     super();
 
-    const { awareness, id, target, metadata } = options;
+    const { awareness, id, target, metadata, menu } = options;
     this._awareness = awareness;
     this._commentID = id;
+    this._activeID = id;
     this._target = target;
     this._metadata = metadata;
+    this._menu = menu;
+
+    this.addClass('jc-CommentWidget');
+    this.node.tabIndex = 0;
   }
 
   render(): ReactRenderElement {
@@ -81,24 +105,27 @@ export class CommentWidget<T> extends ReactWidget {
 
     const _CommentWrapper = (props: CommentWrapperProps): JSX.Element => {
       const { comment } = props;
-      const [replies, setReplies] = React.useState(comment.replies);
       const [isHidden, setIsHidden] = React.useState(true);
       const [isEditable, setIsEditable] = React.useState(false);
 
-      const onBodyClick = (): void => setIsHidden(!isHidden);
       const onEditClick = (item_id: IComment['id']): void => {
         setIsEditable(!isEditable);
         editID = item_id;
       };
-      const onDeleteClick = (): void => {
-        deleteComment(metadata, commentID);
-        this.dispose();
+
+      const onBodyClick = (e: React.MouseEvent): void => {
+        const target = e.target as HTMLElement;
+        const newID = Private.getClickID(target);
+        if (newID != null) {
+          this._activeID = newID;
+        }
+
+        if (target.closest('.jc-Ellipses') == null) {
+          setIsHidden(!isHidden);
+        }
       };
-      const onDeleteReplyClick = (item_id: IComment['id']): void => {
-        const data = replies.filter(r => r.id !== item_id);
-        deleteReply(metadata, item_id, commentID);
-        setReplies(data);
-      };
+
+      const focusComment = (): void => this.node.focus();
 
       const onInputKeydown = (e: React.KeyboardEvent): void => {
         if (e.key != 'Enter') {
@@ -115,7 +142,7 @@ export class CommentWidget<T> extends ReactWidget {
             identity: getIdentity(this._awareness),
             replies: [],
             text: target.textContent!,
-            time : getCommentTimeString()
+            time: getCommentTimeString()
           };
 
           addReply(metadata, reply, commentID);
@@ -127,6 +154,10 @@ export class CommentWidget<T> extends ReactWidget {
           editID = '';
           setIsEditable(false);
         }
+      };
+
+      const onDropdownClick = (e: React.MouseEvent): void => {
+        this._menu.open(e.pageX, e.pageY);
       };
 
       if (comment == null) {
@@ -158,25 +189,29 @@ export class CommentWidget<T> extends ReactWidget {
       }
 
       return (
-        <div className="jc-CommentWithReplies">
-          <JCComment
-            comment={comment}
-            content={getContent(comment)}
-            className="jc-Comment"
-            onEditClick={onEditClick.bind(this, comment.id)}
-            onDeleteClick={onDeleteClick.bind(this)}
-          />
-          <div className="jc-Replies">
-            {replies.map(reply => (
-              <JCComment
-                comment={reply}
-                content={getContent(reply)}
-                className="jc-Comment jc-Reply"
-                onEditClick={onEditClick.bind(this, reply.id)}
-                onDeleteClick={onDeleteReplyClick.bind(this, reply.id)}
-                key={reply.id}
-              />
-            ))}
+        <>
+          <div className="jc-CommentWithReplies" onClick={focusComment}>
+            <JCComment
+              comment={comment}
+              content={getContent(comment)}
+              className="jc-Comment"
+              onEditClick={onEditClick.bind(this, comment.id)}
+              onBodyClick={onBodyClick}
+              onDropdownClick={onDropdownClick}
+            />
+            <div className="jc-Replies">
+              {comment.replies.map(reply => (
+                <JCComment
+                  comment={reply}
+                  content={getContent(reply)}
+                  className="jc-Comment jc-Reply"
+                  onEditClick={onEditClick.bind(this, reply.id)}
+                  onDropdownClick={onDropdownClick}
+                  onBodyClick={onBodyClick}
+                  key={reply.id}
+                />
+              ))}
+            </div>
           </div>
           <div
             className="jc-InputArea"
@@ -184,15 +219,17 @@ export class CommentWidget<T> extends ReactWidget {
             onKeyDown={onInputKeydown}
             contentEditable={true}
           />
-        </div>
+        </>
       );
     };
 
     return <_CommentWrapper comment={this.comment!} />;
   }
 
+  /**
+   * The comment object being rendered by the widget.
+   */
   get comment(): IComment | undefined {
-    console.log('getting comment with id', this.commentID);
     const comments = this._metadata.get('comments');
     if (comments == null) {
       return undefined;
@@ -205,34 +242,68 @@ export class CommentWidget<T> extends ReactWidget {
     );
   }
 
+  /**
+   * The target of the comment (what is being commented on).
+   */
   get target(): T {
     return this._target;
   }
 
+  /**
+   * Information about the author of the comment.
+   */
   get identity(): IIdentity | undefined {
     return this.comment?.identity;
   }
 
+  /**
+   * The type of the comment.
+   */
   get type(): CommentType | undefined {
     return this.comment?.type;
   }
 
+  /**
+   * The plain body text of the comment.
+   */
   get text(): string | undefined {
     return this.comment?.text;
   }
 
+  /**
+   * An array of replies to the comment.
+   */
   get replies(): IComment[] | undefined {
     return this.comment?.replies;
   }
 
+  /**
+   * The ID of the main comment.
+   */
   get commentID(): string {
     return this._commentID;
+  }
+
+  /**
+   * The ID of the last-focused comment or reply.
+   */
+  get activeID(): string {
+    return this._activeID;
+  }
+
+  /**
+   * The metadata object hosting the comment.
+   */
+  get metadata(): IObservableJSON {
+    return this._metadata;
   }
 
   private _awareness: Awareness;
   private _commentID: string;
   private _target: T;
   private _metadata: IObservableJSON;
+  private _activeID: string;
+  private _menu: Menu;
 }
 
 export namespace CommentWidget {
@@ -244,5 +315,20 @@ export namespace CommentWidget {
     metadata: IObservableJSON;
 
     target: T;
+
+    menu: Menu;
+  }
+}
+
+export namespace Private {
+  /**
+   * Get the ID of a comment that a target lies within.
+   */
+  export function getClickID(target: HTMLElement): string | undefined {
+    const comment = target.closest('.jc-Comment');
+    if (comment == null) {
+      return undefined;
+    }
+    return comment.id;
   }
 }

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -63,14 +63,14 @@ function JCComment(props: CommentProps): JSX.Element {
       </div>
       <span className="jc-Nametag">{comment.identity.name}</span>
       <span onClick={onDropdownClick}>
-        <ellipsesIcon.react className="jc-Ellipses" tag="span" />
+        <ellipsesIcon.react className="jc-Ellipses jc-no-reply" tag="span" />
       </span>
       <br />
       <span className="jc-Time">{comment.time}</span>
       <br />
 
       {/* the actual content */}
-      <div className="jc-ContentContainer" onClick={onEditClick}>
+      <div className="jc-ContentContainer jc-no-reply" onClick={onEditClick}>
         {content}
       </div>
 
@@ -109,7 +109,7 @@ export class CommentWidget<T> extends ReactWidget {
       const [isEditable, setIsEditable] = React.useState(false);
 
       const onEditClick = (item_id: IComment['id']): void => {
-        setIsEditable(!isEditable);
+        setIsEditable(true);
         editID = item_id;
       };
 
@@ -120,12 +120,18 @@ export class CommentWidget<T> extends ReactWidget {
           this._activeID = newID;
         }
 
-        if (target.closest('.jc-Ellipses') == null) {
+        if (target.closest('.jc-no-reply') == null) {
           setIsHidden(!isHidden);
+          setIsEditable(false);
         }
       };
 
-      const focusComment = (): void => this.node.focus();
+      const focusComment = (e: React.MouseEvent): void => {
+        const target = e.target as HTMLElement;
+        if (target.closest('.jc-no-reply') == null) {
+          this.node.focus();
+        }
+      };
 
       const onInputKeydown = (e: React.KeyboardEvent): void => {
         if (e.key != 'Enter') {
@@ -166,20 +172,21 @@ export class CommentWidget<T> extends ReactWidget {
 
       function getContent(c: IComment) {
         let normal = (
-          <p className="jc-Body" onClick={onBodyClick}>
+          <div className="jc-Body" onClick={onBodyClick}>
             {c.text}
-          </p>
+          </div>
         );
         let edit_box = (
-          <p className="jc-Body" onClick={onBodyClick}>
+          <div className="jc-Body" onClick={onBodyClick}>
             <div
               className="jc-InputArea"
               onKeyDown={onInputKeydown}
               contentEditable={true}
+              suppressContentEditableWarning={true}
             >
               {c.text}
             </div>
-          </p>
+          </div>
         );
         if (editID == c.id && isEditable) {
           return edit_box;

--- a/style/base.css
+++ b/style/base.css
@@ -31,6 +31,11 @@
   right: 0px;
 }
 
+.jc-EditButton {
+  bottom: 0px;
+  right: 0px;
+}
+
 .jc-Reply {
   border-top: none;
 }

--- a/style/base.css
+++ b/style/base.css
@@ -1,5 +1,6 @@
 .jc-CommentPanel {
   background-color: var(--jp-layout-color0);
+  color: var(--jp-ui-font-color0);
   overflow: auto;
 }
 
@@ -7,7 +8,6 @@
   background-color: var(--jp-layout-color1);
   padding: 15px;
   border: 1px solid #c5c5c5;
-  color: var(--jp-ui-font-color0);
 }
 
 .jc-Nametag {
@@ -60,8 +60,16 @@
   width: 35px;
 }
 
-.jc-CommentWithReplies {
+.jc-CommentWidget {
   margin: 0 8px 12px 8px;
+}
+
+.jc-CommentWidget:focus-within .jc-Comment {
+  border-color: var(--jp-brand-color1);
+}
+
+.jc-CommentWidget:focus-within .jc-InputArea {
+  border-color: var(--jp-brand-color1);
 }
 
 .jc-InputArea {
@@ -69,4 +77,14 @@
   border-top: none;
   padding: 5px 4px;
   min-height: 44px;
+}
+
+.jc-Ellipses {
+  float: right;
+  width: 25px;
+  height: 25px;
+}
+
+.jc-Ellipses > svg {
+  width: 25px;
 }


### PR DESCRIPTION
Addresses Issue #18 

A bit of a chunky PR!
- Added a focus tracker for `CommentWidget`s. Allows for commands that delete/edit/etc the current comment widget.
- Made focused comment widgets have a blue border.
- Added a dropdown menu to comment widgets. Currently only allows for deleting the comment, but it should be easy to add entries.
- Removed buttons for lean, sexy comment widgets.