### PR TITLE
Improved reply and edit box

### DIFF
--- a/src/comments.ts
+++ b/src/comments.ts
@@ -47,6 +47,10 @@ export function addComment(
   metadata: IObservableJSON,
   comment: comments.IComment
 ): void {
+  if (comment.text == ''){
+    console.warn("Empty string cannot be a comment")
+    return;
+  }
   const comments = getComments(metadata);
   if (comments == null) {
     metadata.set('comments', [comment as any]);
@@ -63,6 +67,10 @@ export function edit(
 ): void {
   const comment = getCommentByID(metadata, commentid);
   if (comment == null) {
+    return;
+  }
+  if (modifiedText == ''){
+    console.warn("Empty string cannot be a comment/reply")
     return;
   }
   if (editid == commentid) {
@@ -112,6 +120,10 @@ export function addReply(
   reply: comments.IComment,
   id: string
 ): void {
+  if (reply.text == ''){
+    console.warn("Empty string cannot be a reply")
+    return;
+  }
   const comments = getComments(metadata);
   if (comments == null) {
     return;

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -25,6 +25,14 @@ type CommentProps = {
   onDropdownClick: React.MouseEventHandler;
 };
 
+type ReplyProps = {
+  comment: IComment;
+  className: string;
+  onInputKeydown: React.KeyboardEventHandler;
+  isHidden: boolean;
+
+}
+
 type CommentWrapperProps = {
   comment: IComment;
 };
@@ -75,6 +83,32 @@ function JCComment(props: CommentProps): JSX.Element {
       </div>
 
       <br />
+    </div>
+  );
+}
+
+function JCReply(props: ReplyProps): JSX.Element {
+  const {
+    comment,
+    className,
+    isHidden,
+    onInputKeydown,
+  } = props;
+
+  return (
+    <div hidden={isHidden}>
+      {/* <div
+        className="jc-ProfilePic"
+        style={{ backgroundColor: comment.identity.color }}
+      /> */}
+      {console.log(comment)}
+      
+      <div
+        className={className}
+        onKeyDown={onInputKeydown}
+        contentEditable={true}
+        data-placeholder="reply"
+      />
     </div>
   );
 }
@@ -179,7 +213,7 @@ export class CommentWidget<T> extends ReactWidget {
         let edit_box = (
           <div className="jc-Body" onClick={onBodyClick}>
             <div
-              className="jc-InputArea"
+              className="jc-EditInputArea"
               onKeyDown={onInputKeydown}
               contentEditable={true}
               suppressContentEditableWarning={true}
@@ -220,12 +254,13 @@ export class CommentWidget<T> extends ReactWidget {
               ))}
             </div>
           </div>
-          <div
-            className="jc-InputArea"
-            hidden={isHidden}
-            onKeyDown={onInputKeydown}
-            contentEditable={true}
-          />
+
+          <JCReply className="jc-ReplyInputArea"
+             comment={comment}
+             isHidden={isHidden}
+             onInputKeydown={onInputKeydown}
+            />
+
         </>
       );
     };

--- a/style/base.css
+++ b/style/base.css
@@ -72,11 +72,31 @@
   border-color: var(--jp-brand-color1);
 }
 
+
 .jc-InputArea {
   border: 1px solid #c5c5c5;
   border-top: none;
-  padding: 5px 4px;
-  min-height: 44px;
+  padding: 15px 14px 6px 18px;
+  min-height: 30px;
+}
+
+.jc-EditInputArea {
+  border: 1px solid #c5c5c5;
+  /* border-top: none; */
+  margin-top: 3px;
+  padding: 6px 3px 3px 3px;
+  min-height: 24px;
+}
+
+.jc-ReplyInputArea:empty:before {
+  content: attr(data-placeholder);
+  color: rgba(0, 0, 0, 0.38);
+}
+.jc-ReplyInputArea {
+  border: 1px solid #c5c5c5;
+  border-top: none;
+  padding: 15px 14px 6px 18px;
+  min-height: 30px;
 }
 
 .jc-Ellipses {


### PR DESCRIPTION
Added in changes to the edit box :

<img width="273" alt="Screen Shot 2021-07-05 at 1 00 49 PM" src="https://user-images.githubusercontent.com/59373265/124515583-aa7ab980-dd94-11eb-8e99-88a8cdb1ba7a.png">

I'm not too sure if we should add in the profile pic or anything else since it might clutter the reply.

<img width="273" alt="Screen Shot 2021-07-05 at 12 59 07 PM" src="https://user-images.githubusercontent.com/59373265/124515561-a058bb00-dd94-11eb-8ea2-ca20069f47ab.png">

Will merge after resolving reply box contents.