### PR TITLE
Prevent empty entries for comments and replies

### DIFF
--- a/src/comments.ts
+++ b/src/comments.ts
@@ -69,6 +69,10 @@ export function edit(
   if (comment == null) {
     return;
   }
+  if (modifiedText == ''){
+    console.warn("bleh")
+    return;
+  }
   if (editid == commentid) {
     editComment(metadata, commentid, modifiedText);
   } else {

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -70,7 +70,7 @@ export function edit(
     return;
   }
   if (modifiedText == ''){
-    console.warn("bleh")
+    console.warn("Empty string cannot be a comment/reply")
     return;
   }
   if (editid == commentid) {

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -47,6 +47,10 @@ export function addComment(
   metadata: IObservableJSON,
   comment: comments.IComment
 ): void {
+  if (comment.text == ''){
+    console.warn("Empty string cannot be a comment")
+    return;
+  }
   const comments = getComments(metadata);
   if (comments == null) {
     metadata.set('comments', [comment as any]);
@@ -112,6 +116,10 @@ export function addReply(
   reply: comments.IComment,
   id: string
 ): void {
+  if (reply.text == ''){
+    console.warn("Empty string cannot be a reply")
+    return;
+  }
   const comments = getComments(metadata);
   if (comments == null) {
     return;


### PR DESCRIPTION
Addressed bug from (#38) by blocking off edits to empty strings and preventing addition of comments with empty strings.

