### PR TITLE
Refactored react widget + quality-of-life improvements

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import {
 
 import { InputDialog, WidgetTracker } from '@jupyterlab/apputils';
 import { INotebookTracker } from '@jupyterlab/notebook';
-import { addComment, deleteComment, deleteReply } from './comments';
+import { addComment } from './comments';
 import { UUID } from '@lumino/coreutils';
 import { IComment } from './commentformat';
 import { YNotebook } from '@jupyterlab/shared-models';
@@ -17,6 +17,8 @@ import { CommentWidget } from './widget';
 namespace CommandIDs {
   export const addComment = 'jl-chat:add-comment';
   export const deleteComment = 'jl-chat:delete-comment';
+  export const editComment = 'jl-chat:edit-comment';
+  export const replyToComment = 'jl-chat:reply-to-comment';
 }
 
 /**
@@ -50,8 +52,10 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
     addCommands(app, nbTracker, commentTracker, panel);
 
-    // Add an entry to the drop-down menu for comments
+    // Add entries to the drop-down menu for comments
     panel.commentMenu.addItem({ command: CommandIDs.deleteComment });
+    panel.commentMenu.addItem({ command: CommandIDs.editComment });
+    panel.commentMenu.addItem({ command: CommandIDs.replyToComment });
 
     app.contextMenu.addItem({
       command: CommandIDs.addComment,
@@ -60,9 +64,9 @@ const plugin: JupyterFrontEndPlugin<void> = {
     });
 
     app.contextMenu.addItem({
-      command: CommandIDs.deleteComment,
+      command: 'jl-chat:listen',
       selector: '.jp-Notebook .jp-Cell',
-      rank: 0
+      rank: 14
     });
   }
 };
@@ -76,6 +80,14 @@ function addCommands(
   const getAwareness = (): Awareness | undefined => {
     return (nbTracker.currentWidget?.model?.sharedModel as YNotebook).awareness;
   };
+
+  app.commands.addCommand('jl-chat:listen', {
+    label: 'Listen For Awareness Changes',
+    execute: () => {
+      const awareness = getAwareness();
+      awareness?.on('change', () => console.log(awareness.getLocalState()));
+    }
+  });
 
   app.commands.addCommand(CommandIDs.addComment, {
     label: 'Add Comment',
@@ -111,14 +123,28 @@ function addCommands(
     execute: () => {
       const currentComment = commentTracker.currentWidget;
       if (currentComment != null) {
-        const id = currentComment.activeID;
-        const metadata = currentComment.metadata;
-        if (id === currentComment.commentID) {
-          deleteComment(metadata, id);
-        } else {
-          deleteReply(metadata, id, currentComment.commentID);
-        }
+        currentComment.deleteActive();
         panel.update();
+      }
+    }
+  });
+
+  app.commands.addCommand(CommandIDs.editComment, {
+    label: 'Edit Comment',
+    execute: () => {
+      const currentComment = commentTracker.currentWidget;
+      if (currentComment != null) {
+        currentComment.editActive();
+      }
+    }
+  });
+
+  app.commands.addCommand(CommandIDs.replyToComment, {
+    label: 'Reply to Comment',
+    execute: () => {
+      const currentComment = commentTracker.currentWidget;
+      if (currentComment != null) {
+        currentComment.revealReply();
       }
     }
   });

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -1,13 +1,14 @@
-import { ReactWidget } from '@jupyterlab/apputils';
+import { ReactWidget, UseSignal } from '@jupyterlab/apputils';
 import * as React from 'react';
 import { ellipsesIcon } from '@jupyterlab/ui-components';
 import { CommentType, IComment, IIdentity } from './commentformat';
 import { IObservableJSON } from '@jupyterlab/observables';
 import { UUID } from '@lumino/coreutils';
-import { addReply, edit } from './comments';
+import { addReply, deleteComment, deleteReply, edit } from './comments';
 import { Awareness } from 'y-protocols/awareness';
 import { getCommentTimeString, getIdentity } from './utils';
 import { Menu } from '@lumino/widgets';
+import { Signal } from '@lumino/signaling';
 
 /**
  * This type comes from @jupyterlab/apputils/vdom.ts but isn't exported.
@@ -18,23 +19,24 @@ type ReactRenderElement =
 
 type CommentProps = {
   comment: IComment;
-  className: string;
-  content: ReactRenderElement;
-  onEditClick: React.MouseEventHandler;
-  onBodyClick: React.MouseEventHandler;
-  onDropdownClick: React.MouseEventHandler;
+  className?: string;
+  editable?: boolean;
 };
 
-type ReplyProps = {
+type CommentWithRepliesProps = {
   comment: IComment;
-  className: string;
-  onInputKeydown: React.KeyboardEventHandler;
-  isHidden: boolean;
-
-}
+  editID: string;
+  className?: string;
+};
 
 type CommentWrapperProps = {
-  comment: IComment;
+  commentWidget: CommentWidget<any>;
+  className?: string;
+};
+
+type ReplyAreaProps = {
+  hidden: boolean;
+  className?: string;
 };
 
 /**
@@ -45,70 +47,108 @@ type CommentWrapperProps = {
  *
  * @param className - a string that will be used as the className of the
  * container element.
- *
- * @param onBodyClick - a function that will be run when the comment is clicked.
- *
- * @param onDropdownClick - a function that will be run when the comment's
- * dropdown (ellipses) menu is clicked.
  */
 function JCComment(props: CommentProps): JSX.Element {
-  const {
-    comment,
-    className,
-    content,
-    onBodyClick,
-    onDropdownClick,
-    onEditClick
-  } = props;
+  const comment = props.comment;
+  const className = props.className || '';
 
   return (
-    <div className={className || ''} id={comment.id} onClick={onBodyClick}>
+    <div
+      className={'jc-Comment ' + className}
+      id={comment.id}
+      //@ts-ignore (TypeScript doesn't know about custom attributes)
+      jcEventArea="other"
+    >
       <div className="jc-ProfilePicContainer">
         <div
           className="jc-ProfilePic"
           style={{ backgroundColor: comment.identity.color }}
+          //@ts-ignore (TypeScript doesn't know about custom attributes)
+          jcEventArea="user"
         />
       </div>
       <span className="jc-Nametag">{comment.identity.name}</span>
-      <span onClick={onDropdownClick}>
-        <ellipsesIcon.react className="jc-Ellipses jc-no-reply" tag="span" />
+
+      <span
+        className="jc-IconContainer"
+        //@ts-ignore (TypeScript doesn't know about custom attributes)
+        jcEventArea="dropdown"
+      >
+        <ellipsesIcon.react className="jc-Ellipses" />
       </span>
-      <br />
-      <span className="jc-Time">{comment.time}</span>
+
       <br />
 
-      {/* the actual content */}
-      <div className="jc-ContentContainer jc-no-reply" onClick={onEditClick}>
-        {content}
-      </div>
+      <span className="jc-Time">{comment.time}</span>
+
+      <br />
+
+      <input
+        className="jc-Body"
+        type="text"
+        defaultValue={comment.text}
+        // contentEditable={editable}
+        // suppressContentEditableWarning={true}
+        //@ts-ignore (TypeScript doesn't know about custom attributes)
+        jcEventArea="body"
+      ></input>
 
       <br />
     </div>
   );
 }
 
-function JCReply(props: ReplyProps): JSX.Element {
-  const {
-    comment,
-    className,
-    isHidden,
-    onInputKeydown,
-  } = props;
+function JCCommentWithReplies(props: CommentWithRepliesProps): JSX.Element {
+  const comment = props.comment;
+  const className = props.className || '';
+  const editID = props.editID;
 
   return (
-    <div hidden={isHidden}>
-      {/* <div
-        className="jc-ProfilePic"
-        style={{ backgroundColor: comment.identity.color }}
-      /> */}
-      {console.log(comment)}
-      
-      <div
-        className={className}
-        onKeyDown={onInputKeydown}
-        contentEditable={true}
-        data-placeholder="reply"
+    <div className={'jc-CommentWithReplies ' + className}>
+      <JCComment comment={comment} editable={editID === comment.id} />
+      <div className={'jc-Replies'}>
+        {comment.replies.map(reply => (
+          <JCComment
+            comment={reply}
+            className="jc-Reply"
+            editable={editID === reply.id}
+            key={reply.id}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function JCReplyArea(props: ReplyAreaProps): JSX.Element {
+  const hidden = props.hidden;
+  const className = props.className || '';
+
+  return (
+    <div
+      className={'jc-InputArea ' + className}
+      contentEditable={true}
+      hidden={hidden}
+      //@ts-ignore (TypeScript doesn't know about custom attributes)
+      jcEventArea="reply"
+    />
+  );
+}
+
+function JCCommentWrapper(props: CommentWrapperProps): JSX.Element {
+  const commentWidget = props.commentWidget;
+  const className = props.className || '';
+
+  const onClick = commentWidget.handleEvent.bind(commentWidget);
+  const onKeyDown = onClick;
+
+  return (
+    <div className={className} onClick={onClick} onKeyDown={onKeyDown}>
+      <JCCommentWithReplies
+        comment={commentWidget.comment!}
+        editID={commentWidget.editID}
       />
+      <JCReplyArea hidden={commentWidget.replyAreaHidden} />
     </div>
   );
 }
@@ -132,140 +172,256 @@ export class CommentWidget<T> extends ReactWidget {
     this.node.tabIndex = 0;
   }
 
-  render(): ReactRenderElement {
-    const metadata = this._metadata;
-    const commentID = this.commentID;
-    let editID: IComment['id'];
+  handleEvent(event: React.SyntheticEvent): void {
+    switch (event.type) {
+      case 'click':
+        this._handleClick(event as React.MouseEvent);
+        break;
+      case 'keydown':
+        this._handleKeydown(event as React.KeyboardEvent);
+        break;
+    }
+  }
 
-    const _CommentWrapper = (props: CommentWrapperProps): JSX.Element => {
-      const { comment } = props;
-      const [isHidden, setIsHidden] = React.useState(true);
-      const [isEditable, setIsEditable] = React.useState(false);
+  /**
+   * Handle `click` events on the widget.
+   */
+  private _handleClick(event: React.MouseEvent): void {
+    switch (CommentWidget.getEventArea(event)) {
+      case 'body':
+        this._handleBodyClick(event);
+        break;
+      case 'dropdown':
+        this._handleDropdownClick(event);
+        break;
+      case 'reply':
+        this._handleReplyClick(event);
+        break;
+      case 'user':
+        this._handleUserClick(event);
+        break;
+      case 'other':
+        this._handleOtherClick(event);
+        break;
+      case 'none':
+        break;
+      default:
+        break;
+    }
+  }
 
-      const onEditClick = (item_id: IComment['id']): void => {
-        setIsEditable(true);
-        editID = item_id;
-      };
+  /**
+   * Sets the widget focus and active id on click.
+   *
+   * A building block of other click handlers.
+   */
+  private _setClickFocus(event: React.MouseEvent): void {
+    const oldActive = document.activeElement;
+    const target = event.target as HTMLElement;
+    const clickID = Private.getClickID(target);
 
-      const onBodyClick = (e: React.MouseEvent): void => {
-        const target = e.target as HTMLElement;
-        const newID = Private.getClickID(target);
-        if (newID != null) {
-          this._activeID = newID;
-        }
+    if (clickID != null) {
+      this.activeID = clickID;
+    }
 
-        if (target.closest('.jc-no-reply') == null) {
-          setIsHidden(!isHidden);
-          setIsEditable(false);
-        }
-      };
+    if (oldActive == null || oldActive.closest('.jc-CommentWidget') == null) {
+      this.node.focus();
+    }
+  }
 
-      const focusComment = (e: React.MouseEvent): void => {
-        const target = e.target as HTMLElement;
-        if (target.closest('.jc-no-reply') == null) {
-          this.node.focus();
-        }
-      };
+  /**
+   * Handle a click on the dropdown (ellipses) area of a widget.
+   */
+  private _handleDropdownClick(event: React.MouseEvent): void {
+    this._setClickFocus(event);
+    this._menu.open(event.pageX, event.pageY);
+  }
 
-      const onInputKeydown = (e: React.KeyboardEvent): void => {
-        if (e.key != 'Enter') {
-          return;
-        }
-        e.preventDefault();
-        e.stopPropagation();
-        const target = e.target as HTMLDivElement;
+  /**
+   * Handle a click on the user icon area of a widget.
+   *
+   * ### Note
+   * Currently just acts as an `other` click.
+   */
+  private _handleUserClick(event: React.MouseEvent): void {
+    console.log('clicked user photo!');
+    this._handleOtherClick(event);
+  }
 
-        if (!isEditable && !isHidden) {
-          const reply: IComment = {
-            id: UUID.uuid4(),
-            type: 'cell',
-            identity: getIdentity(this._awareness),
-            replies: [],
-            text: target.textContent!,
-            time: getCommentTimeString()
-          };
+  /**
+   * Handle a click on the widget but not on a specific area.
+   */
+  private _handleOtherClick(event: React.MouseEvent): void {
+    this._setClickFocus(event);
 
-          addReply(metadata, reply, commentID);
-          target.textContent! = '';
-          setIsHidden(true);
-        } else {
-          edit(metadata, commentID, editID, target.textContent!);
-          target.textContent! = '';
-          editID = '';
-          setIsEditable(false);
-        }
-      };
+    const target = event.target as HTMLElement;
+    const clickID = Private.getClickID(target);
+    if (clickID == null) {
+      return;
+    }
 
-      const onDropdownClick = (e: React.MouseEvent): void => {
-        this._menu.open(e.pageX, e.pageY);
-      };
+    this.editID = '';
 
-      if (comment == null) {
-        return <div className="jc-MissingComment" />;
-      }
+    if (this.replyAreaHidden) {
+      this.revealReply();
+    } else {
+      this.replyAreaHidden = true;
+    }
+  }
 
-      function getContent(c: IComment) {
-        let normal = (
-          <div className="jc-Body" onClick={onBodyClick}>
-            {c.text}
-          </div>
-        );
-        let edit_box = (
-          <div className="jc-Body" onClick={onBodyClick}>
-            <div
-              className="jc-EditInputArea"
-              onKeyDown={onInputKeydown}
-              contentEditable={true}
-              suppressContentEditableWarning={true}
-            >
-              {c.text}
-            </div>
-          </div>
-        );
-        if (editID == c.id && isEditable) {
-          return edit_box;
-        } else {
-          return normal;
-        }
-      }
+  /**
+   * Handle a click on the widget's reply area.
+   */
+  private _handleReplyClick(event: React.MouseEvent): void {
+    this._setClickFocus(event);
+  }
 
-      return (
-        <>
-          <div className="jc-CommentWithReplies" onClick={focusComment}>
-            <JCComment
-              comment={comment}
-              content={getContent(comment)}
-              className="jc-Comment"
-              onEditClick={onEditClick.bind(this, comment.id)}
-              onBodyClick={onBodyClick}
-              onDropdownClick={onDropdownClick}
-            />
-            <div className="jc-Replies">
-              {comment.replies.map(reply => (
-                <JCComment
-                  comment={reply}
-                  content={getContent(reply)}
-                  className="jc-Comment jc-Reply"
-                  onEditClick={onEditClick.bind(this, reply.id)}
-                  onDropdownClick={onDropdownClick}
-                  onBodyClick={onBodyClick}
-                  key={reply.id}
-                />
-              ))}
-            </div>
-          </div>
+  /**
+   * Handle a click on the widget's body.
+   */
+  private _handleBodyClick(event: React.MouseEvent): void {
+    this._setClickFocus(event);
+    this.editActive();
+  }
 
-          <JCReply className="jc-ReplyInputArea"
-             comment={comment}
-             isHidden={isHidden}
-             onInputKeydown={onInputKeydown}
-            />
+  /**
+   * Handle `keydown` events on the widget.
+   */
+  private _handleKeydown(event: React.KeyboardEvent): void {
+    switch (CommentWidget.getEventArea(event)) {
+      case 'reply':
+        this._handleReplyKeydown(event);
+        break;
+      case 'body':
+        this._handleBodyKeydown(event);
+        break;
+      default:
+        break;
+    }
+  }
 
-        </>
-      );
+  /**
+   * Handle a keydown on the widget's reply area.
+   */
+  private _handleReplyKeydown(event: React.KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      this.replyAreaHidden = true;
+      return;
+    } else if (event.key !== 'Enter') {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const target = event.target as HTMLInputElement;
+
+    const reply: IComment = {
+      id: UUID.uuid4(),
+      type: 'cell',
+      identity: getIdentity(this._awareness),
+      replies: [],
+      text: target.value,
+      time: getCommentTimeString()
     };
 
-    return <_CommentWrapper comment={this.comment!} />;
+    addReply(this.metadata, reply, this.commentID);
+    target.value = '';
+    this.replyAreaHidden = true;
+  }
+
+  /**
+   * Handle a keydown on the widget's body.
+   */
+  private _handleBodyKeydown(event: React.KeyboardEvent): void {
+    if (this.editID === '') {
+      return;
+    }
+
+    const target = event.target as HTMLInputElement;
+
+    switch (event.key) {
+      case 'Escape':
+        event.preventDefault();
+        event.stopPropagation();
+        this.editID = '';
+        target.blur();
+        break;
+      case 'Enter':
+        event.preventDefault();
+        event.stopPropagation();
+        edit(this.metadata, this.commentID, this.activeID, target.value);
+        this.editID = '';
+        target.blur();
+        break;
+      default:
+        break;
+    }
+  }
+
+  render(): ReactRenderElement {
+    return (
+      <UseSignal signal={this.renderNeeded}>
+        {() => <JCCommentWrapper commentWidget={this} />}
+      </UseSignal>
+    );
+  }
+
+  /**
+   * Open the widget's reply area and focus on it.
+   */
+  revealReply(): void {
+    if (this.isAttached === false) {
+      return;
+    }
+
+    this.replyAreaHidden = false;
+    const nodes = this.node.getElementsByClassName(
+      'jc-InputArea'
+    ) as HTMLCollectionOf<HTMLDivElement>;
+    nodes[0].focus();
+  }
+
+  /**
+   * Select the body area of the currently active comment for editing.
+   */
+  editActive(): void {
+    if (this.isAttached === false) {
+      return;
+    }
+
+    const comment = document.getElementById(this.activeID);
+    if (comment == null) {
+      return;
+    }
+
+    if (this.editID !== this.activeID) {
+      this.editID = this.activeID;
+      const elements = comment.getElementsByClassName(
+        'jc-Body'
+      ) as HTMLCollectionOf<HTMLInputElement>;
+      const target = elements[0];
+      target.select();
+    }
+  }
+
+  /**
+   * Delete the currently active comment or reply.
+   *
+   * ### Notes
+   * If the base comment is deleted, the widget will be disposed.
+   */
+  deleteActive(): void {
+    if (this.isAttached === false) {
+      return;
+    }
+
+    if (this.activeID === this.commentID) {
+      deleteComment(this.metadata, this.commentID);
+      this.dispose();
+    } else {
+      deleteReply(this.metadata, this.activeID, this.commentID);
+    }
   }
 
   /**
@@ -332,6 +488,12 @@ export class CommentWidget<T> extends ReactWidget {
   get activeID(): string {
     return this._activeID;
   }
+  set activeID(newVal: string) {
+    if (newVal !== this.activeID) {
+      this._activeID = newVal;
+      this._renderNeeded.emit(undefined);
+    }
+  }
 
   /**
    * The metadata object hosting the comment.
@@ -340,12 +502,50 @@ export class CommentWidget<T> extends ReactWidget {
     return this._metadata;
   }
 
+  /**
+   * Whether to show the reply area or not
+   */
+  get replyAreaHidden(): boolean {
+    return this._replyAreaHidden;
+  }
+  set replyAreaHidden(newVal: boolean) {
+    if (newVal !== this.replyAreaHidden) {
+      this._replyAreaHidden = newVal;
+      this._renderNeeded.emit(undefined);
+    }
+  }
+
+  /**
+   * A signal emitted when a React re-render is required.
+   */
+  get renderNeeded(): Signal<this, undefined> {
+    return this._renderNeeded;
+  }
+
+  /**
+   * The ID of the managed comment being edited, or the empty string if none.
+   */
+  get editID(): string {
+    return this._editID;
+  }
+  set editID(newVal: string) {
+    if (this.editID !== newVal) {
+      this._editID = newVal;
+      this._renderNeeded.emit(undefined);
+    }
+  }
+
   private _awareness: Awareness;
   private _commentID: string;
   private _target: T;
   private _metadata: IObservableJSON;
   private _activeID: string;
   private _menu: Menu;
+  private _replyAreaHidden: boolean = true;
+  private _editID: string = '';
+  private _renderNeeded: Signal<this, undefined> = new Signal<this, undefined>(
+    this
+  );
 }
 
 export namespace CommentWidget {
@@ -359,6 +559,53 @@ export namespace CommentWidget {
     target: T;
 
     menu: Menu;
+  }
+
+  /**
+   * A type referring to an area of a `CommentWidget`
+   */
+  export type EventArea =
+    | 'dropdown'
+    | 'body'
+    | 'user'
+    | 'reply'
+    | 'other'
+    | 'none';
+
+  /**
+   * Whether a string is a type of `EventArea`
+   */
+  export function isEventArea(input: string): input is EventArea {
+    return ['dropdown', 'body', 'user', 'reply', 'other', 'none'].includes(
+      input
+    );
+  }
+
+  /**
+   * Gets the `EventArea` of an event on a `CommentWidget`.
+   *
+   * Returns `none` if the event has no ancestors with the `jcEventArea` attribute,
+   * and returns `other` if `jcEventArea` is set but the value is unrecognized.
+   *
+   * ### Notes
+   * Also sets the target of the event to the first ancestor of the target with
+   * the `jcEventArea` attribute set.
+   */
+  export function getEventArea(event: React.SyntheticEvent): EventArea {
+    const target = event.target as HTMLElement;
+    const areaElement = target.closest('[jcEventArea]');
+    if (areaElement == null) {
+      return 'none';
+    }
+
+    const area = areaElement.getAttribute('jcEventArea');
+    if (area == null) {
+      return 'other';
+    }
+
+    event.target = areaElement;
+
+    return isEventArea(area) ? area : 'other';
   }
 }
 

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -25,6 +25,14 @@ type CommentProps = {
   onDropdownClick: React.MouseEventHandler;
 };
 
+type ReplyProps = {
+  comment: IComment;
+  className: string;
+  onInputKeydown: React.KeyboardEventHandler;
+  isHidden: boolean;
+
+}
+
 type CommentWrapperProps = {
   comment: IComment;
 };
@@ -75,6 +83,32 @@ function JCComment(props: CommentProps): JSX.Element {
       </div>
 
       <br />
+    </div>
+  );
+}
+
+function JCReply(props: ReplyProps): JSX.Element {
+  const {
+    comment,
+    className,
+    isHidden,
+    onInputKeydown,
+  } = props;
+
+  return (
+    <div hidden={isHidden}>
+      {/* <div
+        className="jc-ProfilePic"
+        style={{ backgroundColor: comment.identity.color }}
+      /> */}
+      {console.log(comment)}
+      
+      <div
+        className={className}
+        onKeyDown={onInputKeydown}
+        contentEditable={true}
+        data-placeholder="reply"
+      />
     </div>
   );
 }
@@ -179,7 +213,7 @@ export class CommentWidget<T> extends ReactWidget {
         let edit_box = (
           <div className="jc-Body" onClick={onBodyClick}>
             <div
-              className="jc-InputArea"
+              className="jc-EditInputArea"
               onKeyDown={onInputKeydown}
               contentEditable={true}
               suppressContentEditableWarning={true}
@@ -220,12 +254,13 @@ export class CommentWidget<T> extends ReactWidget {
               ))}
             </div>
           </div>
-          <div
-            className="jc-InputArea"
-            hidden={isHidden}
-            onKeyDown={onInputKeydown}
-            contentEditable={true}
-          />
+
+          <JCReply className="jc-ReplyInputArea"
+             comment={comment}
+             isHidden={isHidden}
+             onInputKeydown={onInputKeydown}
+            />
+
         </>
       );
     };

--- a/style/base.css
+++ b/style/base.css
@@ -82,7 +82,7 @@
   border-color: var(--jp-brand-color1);
 }
 
-.jc-CommentWidget:focus-within .jc-InputArea {
+.jc-CommentWidget:focus-within .jc-ReplyInputArea {
   border-color: var(--jp-brand-color1);
 }
 
@@ -94,8 +94,6 @@
 }
 
 .jc-EditInputArea {
-  border: 1px solid #c5c5c5;
-  /* border-top: none; */
   margin-top: 3px;
   padding: 6px 3px 3px 3px;
   min-height: 24px;
@@ -103,13 +101,14 @@
 
 .jc-ReplyInputArea:empty:before {
   content: attr(data-placeholder);
-  color: rgba(0, 0, 0, 0.38);
+  color: var(--jp-ui-font-color3);
 }
 .jc-ReplyInputArea {
   border: 1px solid #c5c5c5;
   border-top: none;
   padding: 15px 14px 6px 18px;
   min-height: 30px;
+  word-break: break-word;
 }
 
 .jc-Ellipses {

--- a/style/base.css
+++ b/style/base.css
@@ -10,6 +10,10 @@
   border: 1px solid #c5c5c5;
 }
 
+.jc-Comment:hover .jc-Ellipses {
+  display: inline-block;
+}
+
 .jc-Nametag {
   font-weight: bold;
   margin-left: 10px;
@@ -24,6 +28,16 @@
 
 .jc-Body {
   display: inline-block;
+  outline: none;
+  border: none;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-color: transparent;
+}
+
+.jc-Body:focus {
+  outline: 1px solid var(--jp-ui-font-color3);
 }
 
 .jc-DeleteButton {
@@ -72,7 +86,6 @@
   border-color: var(--jp-brand-color1);
 }
 
-
 .jc-InputArea {
   border: 1px solid #c5c5c5;
   border-top: none;
@@ -103,6 +116,7 @@
   float: right;
   width: 25px;
   height: 25px;
+  display: none;
 }
 
 .jc-Ellipses > svg {

--- a/style/base.css
+++ b/style/base.css
@@ -72,11 +72,31 @@
   border-color: var(--jp-brand-color1);
 }
 
+
 .jc-InputArea {
   border: 1px solid #c5c5c5;
   border-top: none;
-  padding: 5px 4px;
-  min-height: 44px;
+  padding: 15px 14px 6px 18px;
+  min-height: 30px;
+}
+
+.jc-EditInputArea {
+  border: 1px solid #c5c5c5;
+  /* border-top: none; */
+  margin-top: 3px;
+  padding: 6px 3px 3px 3px;
+  min-height: 24px;
+}
+
+.jc-ReplyInputArea:empty:before {
+  content: attr(data-placeholder);
+  color: rgba(0, 0, 0, 0.38);
+}
+.jc-ReplyInputArea {
+  border: 1px solid #c5c5c5;
+  border-top: none;
+  padding: 15px 14px 6px 18px;
+  min-height: 30px;
 }
 
 .jc-Ellipses {


### PR DESCRIPTION
This PR implements core changes/simplifications to how comment widgets are rendered, as well as some general usability/quality-of-life improvements.

The single huge `render()` function of comments has been broken up into several smaller react components and wrapped in a `<UseSignal/>` component, which allows for easier re-rendering. In addition, the `handleEvent()` CommentWidget method handles all click and keydown events across the widget. Events are dispatched according to the area of the widget they occur on, which is determined by the `CommentWidget.getEventArea()` function. Hopefully these changes make it easier to add elements and handle events without a whole mess of hooks and nested functions.

Some QOL improvements:
- Ellipses/dropdown only visible when the comment widget is hovered over.
- Opening the edit/reply box for a widget automatically sets focus to the box.
- Delete, edit, and reply are now accessible through public CommentWidget methods and lumino commands.
- Edit and reply are now added to the comment widget's dropdown menu.
- The body of comments are now input elements. This avoids some difficulties with `contentEditable` elements but I left the editID machinery in place in case we want to go back.

Bugs:
Opening a reply dialog by clicking on the widget (not using the context menu) doesn't focus on the reply area and I'm not sure why.