### PR TITLE
Unified comments panel

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,12 @@
 import {
+  ILabShell,
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 
 import { InputDialog, WidgetTracker } from '@jupyterlab/apputils';
 import { INotebookTracker } from '@jupyterlab/notebook';
-import { addComment } from './comments';
+import { addComment, getComments } from './comments';
 import { UUID } from '@lumino/coreutils';
 import { IComment } from './commentformat';
 import { YNotebook } from '@jupyterlab/shared-models';
@@ -13,6 +14,7 @@ import { Awareness } from 'y-protocols/awareness';
 import { getCommentTimeString, getIdentity } from './utils';
 import { CommentPanel } from './panel';
 import { CommentWidget } from './widget';
+import { Cell } from '@jupyterlab/cells';
 
 namespace CommandIDs {
   export const addComment = 'jl-chat:add-comment';
@@ -27,8 +29,12 @@ namespace CommandIDs {
 const plugin: JupyterFrontEndPlugin<void> = {
   id: 'jupyterlab-chat:plugin',
   autoStart: true,
-  requires: [INotebookTracker],
-  activate: (app: JupyterFrontEnd, nbTracker: INotebookTracker) => {
+  requires: [INotebookTracker, ILabShell],
+  activate: (
+    app: JupyterFrontEnd,
+    nbTracker: INotebookTracker,
+    shell: ILabShell
+  ) => {
     // A widget tracker for comment widgets
     const commentTracker = new WidgetTracker<CommentWidget<any>>({
       namespace: 'comment-widgets'
@@ -39,7 +45,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
       tracker: nbTracker,
       commands: app.commands
     });
-    app.shell.add(panel, 'right', { rank: 500 });
+    shell.add(panel, 'right', { rank: 500 });
 
     // Automatically add the comment widgets to the tracker as
     // they're added to the panel
@@ -47,8 +53,23 @@ const plugin: JupyterFrontEndPlugin<void> = {
       (_, comment) => void commentTracker.add(comment)
     );
 
-    // Re-render the panel whenever the active cell changes
-    nbTracker.activeCellChanged.connect((_, cells) => panel.update());
+    shell.currentChanged.connect(() => panel.update());
+
+    const onActiveCellChanged = (_: any, cell: Cell | null): void => {
+      if (cell == null) {
+        return;
+      }
+
+      const comments = getComments(cell!.model.metadata);
+      if (comments == null) {
+        return;
+      }
+
+      panel.scrollToComment(comments[0].id);
+    };
+
+    // Scroll to a cell's comments when that cell is focused.
+    nbTracker.activeCellChanged.connect(onActiveCellChanged);
 
     addCommands(app, nbTracker, commentTracker, panel);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,8 @@ const plugin: JupyterFrontEndPlugin<void> = {
       (_, comment) => void commentTracker.add(comment)
     );
 
+    panel.revealed.connect(() => panel.update());
+
     shell.currentChanged.connect(() => panel.update());
 
     const onActiveCellChanged = (_: any, cell: Cell | null): void => {

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -148,6 +148,9 @@ export class CommentPanel extends Panel {
     this._commentAdded.emit(widget);
   }
 
+  /**
+   * Scroll the comment with the given id into view.
+   */
   scrollToComment(id: string): void {
     const node = document.getElementById(id);
     if (node == null) {
@@ -155,6 +158,21 @@ export class CommentPanel extends Panel {
     }
 
     node.scrollIntoView({ behavior: 'smooth' });
+  }
+
+  /**
+   * Show the widget, make it visible to its parent widget, and emit the
+   * `revealed` signal.
+   *
+   * ### Notes
+   * This causes the [[isHidden]] property to be false.
+   * If the widget is not explicitly hidden, this is a no-op.
+   */
+  show(): void {
+    if (this.isHidden) {
+      this._revealed.emit(undefined);
+      super.show();
+    }
   }
 
   /**
@@ -171,6 +189,13 @@ export class CommentPanel extends Panel {
     return this._commentMenu;
   }
 
+  /**
+   * A signal emitted when the panel is about to be shown.
+   */
+  get revealed(): Signal<this, undefined> {
+    return this._revealed;
+  }
+
   get awareness(): Awareness | undefined {
     const sharedModel = this._tracker.currentWidget?.context.model.sharedModel;
     if (sharedModel == null) {
@@ -182,6 +207,7 @@ export class CommentPanel extends Panel {
   private _tracker: INotebookTracker;
   private _inputWidget: Widget;
   private _commentAdded = new Signal<this, CommentWidget<any>>(this);
+  private _revealed = new Signal<this, undefined>(this);
   private _commentMenu: Menu;
 }
 


### PR DESCRIPTION
Addresses Issue #24 

The comment panel now displays comments at the document level instead of the cell level. The panel is updated whenever the active document changes and clicking a cell now scrolls the first comment on that cell into view.

![unified_scroll](https://user-images.githubusercontent.com/38936057/124975274-b6f45180-dfe2-11eb-89f4-4412e3435436.gif)

This PR also adds a `revealed` signal in the panel widget.