### PR TITLE
Compact widgets

### DIFF
--- a/src/comments.ts
+++ b/src/comments.ts
@@ -47,8 +47,8 @@ export function addComment(
   metadata: IObservableJSON,
   comment: comments.IComment
 ): void {
-  if (comment.text == ''){
-    console.warn("Empty string cannot be a comment")
+  if (comment.text == '') {
+    console.warn('Empty string cannot be a comment');
     return;
   }
   const comments = getComments(metadata);
@@ -69,8 +69,8 @@ export function edit(
   if (comment == null) {
     return;
   }
-  if (modifiedText == ''){
-    console.warn("Empty string cannot be a comment/reply")
+  if (modifiedText == '') {
+    console.warn('Empty string cannot be a comment/reply');
     return;
   }
   if (editid == commentid) {
@@ -97,7 +97,7 @@ function editReply(
   }
   comment.replies[replyIndex].text = modifiedText;
   // Maybe we should inclued an edited flag to render?
-  comment.time = getCommentTimeString(); 
+  comment.time = getCommentTimeString();
 }
 
 function editComment(
@@ -112,7 +112,7 @@ function editComment(
   }
   comment.text = modifiedText;
   // Maybe we should inclued an edited flag to render?
-  comment.time = getCommentTimeString(); 
+  comment.time = getCommentTimeString();
 }
 
 export function addReply(
@@ -120,8 +120,8 @@ export function addReply(
   reply: comments.IComment,
   id: string
 ): void {
-  if (reply.text == ''){
-    console.warn("Empty string cannot be a reply")
+  if (reply.text == '') {
+    console.warn('Empty string cannot be a reply');
     return;
   }
   const comments = getComments(metadata);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,12 @@
 import {
+  ILabShell,
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 
 import { InputDialog, WidgetTracker } from '@jupyterlab/apputils';
 import { INotebookTracker } from '@jupyterlab/notebook';
-import { addComment } from './comments';
+import { addComment, getComments } from './comments';
 import { UUID } from '@lumino/coreutils';
 import { IComment } from './commentformat';
 import { YNotebook } from '@jupyterlab/shared-models';
@@ -13,6 +14,7 @@ import { Awareness } from 'y-protocols/awareness';
 import { getCommentTimeString, getIdentity } from './utils';
 import { CommentPanel } from './panel';
 import { CommentWidget } from './widget';
+import { Cell } from '@jupyterlab/cells';
 
 namespace CommandIDs {
   export const addComment = 'jl-chat:add-comment';
@@ -27,8 +29,12 @@ namespace CommandIDs {
 const plugin: JupyterFrontEndPlugin<void> = {
   id: 'jupyterlab-chat:plugin',
   autoStart: true,
-  requires: [INotebookTracker],
-  activate: (app: JupyterFrontEnd, nbTracker: INotebookTracker) => {
+  requires: [INotebookTracker, ILabShell],
+  activate: (
+    app: JupyterFrontEnd,
+    nbTracker: INotebookTracker,
+    shell: ILabShell
+  ) => {
     // A widget tracker for comment widgets
     const commentTracker = new WidgetTracker<CommentWidget<any>>({
       namespace: 'comment-widgets'
@@ -39,7 +45,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
       tracker: nbTracker,
       commands: app.commands
     });
-    app.shell.add(panel, 'right', { rank: 500 });
+    shell.add(panel, 'right', { rank: 500 });
 
     // Automatically add the comment widgets to the tracker as
     // they're added to the panel
@@ -47,8 +53,23 @@ const plugin: JupyterFrontEndPlugin<void> = {
       (_, comment) => void commentTracker.add(comment)
     );
 
-    // Re-render the panel whenever the active cell changes
-    nbTracker.activeCellChanged.connect((_, cells) => panel.update());
+    shell.currentChanged.connect(() => panel.update());
+
+    const onActiveCellChanged = (_: any, cell: Cell | null): void => {
+      if (cell == null) {
+        return;
+      }
+
+      const comments = getComments(cell!.model.metadata);
+      if (comments == null) {
+        return;
+      }
+
+      panel.scrollToComment(comments[0].id);
+    };
+
+    // Scroll to a cell's comments when that cell is focused.
+    nbTracker.activeCellChanged.connect(onActiveCellChanged);
 
     addCommands(app, nbTracker, commentTracker, panel);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,8 @@ const plugin: JupyterFrontEndPlugin<void> = {
       (_, comment) => void commentTracker.add(comment)
     );
 
+    panel.revealed.connect(() => panel.update());
+
     shell.currentChanged.connect(() => panel.update());
 
     const onActiveCellChanged = (_: any, cell: Cell | null): void => {

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -97,6 +97,7 @@ export class CommentPanel extends Panel {
 
     const tracker = this._tracker;
     const model = tracker.currentWidget?.model;
+
     if (model == null) {
       console.warn(
         'Either no current widget or no widget model; aborting panel render'

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -148,6 +148,9 @@ export class CommentPanel extends Panel {
     this._commentAdded.emit(widget);
   }
 
+  /**
+   * Scroll the comment with the given id into view.
+   */
   scrollToComment(id: string): void {
     const node = document.getElementById(id);
     if (node == null) {
@@ -155,6 +158,21 @@ export class CommentPanel extends Panel {
     }
 
     node.scrollIntoView({ behavior: 'smooth' });
+  }
+
+  /**
+   * Show the widget, make it visible to its parent widget, and emit the
+   * `revealed` signal.
+   *
+   * ### Notes
+   * This causes the [[isHidden]] property to be false.
+   * If the widget is not explicitly hidden, this is a no-op.
+   */
+  show(): void {
+    if (this.isHidden) {
+      this._revealed.emit(undefined);
+      super.show();
+    }
   }
 
   /**
@@ -171,6 +189,13 @@ export class CommentPanel extends Panel {
     return this._commentMenu;
   }
 
+  /**
+   * A signal emitted when the panel is about to be shown.
+   */
+  get revealed(): Signal<this, undefined> {
+    return this._revealed;
+  }
+
   get awareness(): Awareness | undefined {
     const sharedModel = this._tracker.currentWidget?.context.model.sharedModel;
     if (sharedModel == null) {
@@ -182,6 +207,7 @@ export class CommentPanel extends Panel {
   private _tracker: INotebookTracker;
   private _inputWidget: Widget;
   private _commentAdded = new Signal<this, CommentWidget<any>>(this);
+  private _revealed = new Signal<this, undefined>(this);
   private _commentMenu: Menu;
 }
 

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -348,13 +348,23 @@ export class CommentWidget<T> extends ReactWidget {
       case 'Escape':
         event.preventDefault();
         event.stopPropagation();
+        target.textContent = this.text!;
         this.editID = '';
         target.blur();
         break;
       case 'Enter':
         event.preventDefault();
         event.stopPropagation();
-        edit(this.metadata, this.commentID, this.activeID, target.textContent!);
+        if (target.textContent === '') {
+          target.textContent = this.text!;
+        } else {
+          edit(
+            this.metadata,
+            this.commentID,
+            this.activeID,
+            target.textContent!
+          );
+        }
         this.editID = '';
         target.blur();
         break;

--- a/style/base.css
+++ b/style/base.css
@@ -1,29 +1,47 @@
+:root {
+  --jc-dropdown-size: 25px;
+
+  --jc-profile-pic-size: 32px;
+
+  --jc-panel-background-color: var(--jp-layout-color0);
+
+  --jc-comment-color: var(--jp-ui-font-color0);
+  --jc-comment-background-color: var(--jp-layout-color1);
+  --jc-comment-border-color: #c5c5c5;
+  --jc-comment-border: 1px solid var(--jc-comment-border-color);
+
+  --jc-timestamp-color: var(--jp-ui-font-color2);
+  --jc-timestamp-font-size: smaller;
+  --jc-timestamp-font-weight: regular;
+
+  --jc-nametag-font-size: normal;
+  --jc-nametag-font-weight: 500;
+}
+
 .jc-CommentPanel {
-  background-color: var(--jp-layout-color0);
-  color: var(--jp-ui-font-color0);
+  background-color: var(--jc-panel-background-color);
+  color: var(--jc-widget-color);
   overflow: auto;
 }
 
 .jc-Comment {
-  background-color: var(--jp-layout-color1);
-  padding: 15px;
-  border: 1px solid #c5c5c5;
-}
-
-.jc-Comment:hover .jc-Ellipses {
-  display: inline-block;
+  background-color: var(--jc-comment-background-color);
+  padding: 10px 10px 7px 10px;
+  border: var(--jc-comment-border);
 }
 
 .jc-Nametag {
-  font-weight: bold;
+  font-size: var(--jc-nametag-font-size);
+  font-weight: var(--jc-nametag-font-weight);
   margin-left: 10px;
 }
 
 .jc-Time {
-  font-size: smaller;
+  font-size: var(--jc-timestamp-font-size);
+  font-weight: var(--jc-timestamp-font-weight);
+  color: var(--jc-timestamp-color);
   vertical-align: top;
   margin-left: 10px;
-  color: var(--jp-ui-font-color2);
 }
 
 .jc-Body {
@@ -38,16 +56,6 @@
 
 .jc-Body:focus {
   outline: 1px solid var(--jp-ui-font-color3);
-}
-
-.jc-DeleteButton {
-  bottom: 0px;
-  right: 0px;
-}
-
-.jc-EditButton {
-  bottom: 0px;
-  right: 0px;
 }
 
 .jc-Reply {
@@ -65,38 +73,26 @@
   border-radius: 50%;
   top: 0;
   left: 0;
-  height: 35px;
-  width: 35px;
+  height: var(--jc-profile-pic-size);
+  width: var(--jc-profile-pic-size);
 }
-
 .jc-ProfilePicContainer {
   float: left;
-  width: 35px;
+  width: var(--jc-profile-pic-size);
 }
 
 .jc-CommentWidget {
   margin: 0 8px 12px 8px;
 }
-
 .jc-CommentWidget:focus-within .jc-Comment {
   border-color: var(--jp-brand-color1);
 }
-
 .jc-CommentWidget:focus-within .jc-ReplyInputArea {
   border-color: var(--jp-brand-color1);
 }
 
-.jc-InputArea {
-  border: 1px solid #c5c5c5;
-  border-top: none;
-  padding: 15px 14px 6px 18px;
-  min-height: 30px;
-}
-
 .jc-EditInputArea {
-  margin-top: 3px;
-  padding: 6px 3px 3px 3px;
-  min-height: 24px;
+  padding: 3px 3px 3px 3px;
 }
 
 .jc-ReplyInputArea:empty:before {
@@ -104,20 +100,22 @@
   color: var(--jp-ui-font-color3);
 }
 .jc-ReplyInputArea {
-  border: 1px solid #c5c5c5;
+  border: var(--jc-comment-border);
   border-top: none;
-  padding: 15px 14px 6px 18px;
-  min-height: 30px;
+  padding: 10px;
+  /* min-height: 30px; */
   word-break: break-word;
 }
 
 .jc-Ellipses {
   float: right;
-  width: 25px;
-  height: 25px;
+  width: var(--jc-dropdown-size);
+  height: var(--jc-dropdown-size);
   display: none;
 }
-
+.jc-Comment:hover .jc-Ellipses {
+  display: inline-block;
+}
 .jc-Ellipses > svg {
-  width: 25px;
+  width: var(--jc-dropdown-size);
 }


### PR DESCRIPTION
Sort of addresses Issue #34 ?

Includes commits from PR #43 

Added some styling changes to make comment widgets more compact. Also fixed a bug where editing a comment's text to be empty leaves the body empty until a re-render.

A comparison of the old vs the new styling: (new left, old right)
<img width="269" alt="image" src="https://user-images.githubusercontent.com/38936057/124993267-fe85d800-dff8-11eb-8a1f-6eb64db045d8.png">  <img width="269" alt="image" src="https://user-images.githubusercontent.com/38936057/124993487-46a4fa80-dff9-11eb-81ab-b9e083bed4e9.png">