### PR TITLE
started work on comment preview

### DIFF
--- a/src/commentformat.ts
+++ b/src/commentformat.ts
@@ -1,3 +1,5 @@
+import { ICellModel } from '@jupyterlab/cells';
+
 /**
  * A type for the 'target' of a comment.
  */
@@ -10,6 +12,12 @@ export interface IIdentity {
   id: number;
   name: string;
   color: string;
+}
+
+export interface ISelection {
+  start: number;
+  end: number;
+  source: ICellModel;
 }
 
 /**

--- a/style/base.css
+++ b/style/base.css
@@ -16,11 +16,13 @@
 
   --jc-nametag-font-size: normal;
   --jc-nametag-font-weight: 500;
+
+  --var-jc-linesep: 2px;
 }
 
 .jc-CommentPanel {
   background-color: var(--jc-panel-background-color);
-  color: var(--jc-widget-color);
+  color: var(--jc-comment-color);
   overflow: auto;
 }
 
@@ -45,7 +47,7 @@
 }
 
 .jc-Body {
-  display: inline-block;
+  display: block;
   outline: none;
   border: none;
   appearance: none;
@@ -69,7 +71,7 @@
 }
 
 .jc-ProfilePic {
-  display: inline-block;
+  display: block;
   border-radius: 50%;
   top: 0;
   left: 0;
@@ -92,7 +94,8 @@
 }
 
 .jc-EditInputArea {
-  padding: 3px 3px 3px 3px;
+  margin-top: var(--var-jc-linesep);
+  padding: 3px;
 }
 
 .jc-ReplyInputArea:empty:before {
@@ -118,4 +121,23 @@
 }
 .jc-Ellipses > svg {
   width: var(--jc-dropdown-size);
+}
+
+.jc-Preview {
+  display: grid;
+  grid-template-columns: 6px calc(100% - 6px);
+  padding-left: 10px;
+  margin-top: var(--var-jc-linesep);
+}
+.jc-PreviewBar {
+  width: 2px;
+  height: 100%;
+  background-color: orange;
+}
+.jc-PreviewText {
+  color: var(--jc-timestamp-color);
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin-left: 10px;
 }


### PR DESCRIPTION
Addresses Issue #20 

<img width="266" alt="image" src="https://user-images.githubusercontent.com/38936057/125006496-1f5b2700-e013-11eb-8339-6133bfa22847.png">

Added a comment preview area. Currently just prints the text of the comment but will be modified to show the contents of a text selection.

Also fixed a dark mode display bug.